### PR TITLE
fix(monitor): report machine IP from the probe payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ monitor:
 
 `reportToken` 为空时不验证；设置后，HTTP 和 WebSocket 请求都需要携带 `?token=对应值`。
 
+选手机的 IP 以上报内容中的 `ip` 字段为准，只有该字段缺失或不是合法的可路由地址时才回退到连接来源地址。服务端置于 Nginx 等反向代理之后时，连接来源地址会退化成 `127.0.0.1`，此时仍能记录到选手机真实的内网地址，SSH 与 Prometheus `/sd` 也能正常使用。
+
 `monitor.auto.group` 为 `true` 时使用 hostname 开头的连续字母作为 Group；设置为数字 N 时使用 hostname 的前 N 位；设置为字符串时与其他 `monitor.auto` 字段一样使用模板，例如 `[hostname:1]`。未配置的字段不会修改。
 
 Machine Tools 提供选手机本地配置页和赛前展示页。配置页根据服务器地址生成 `/report`、`/probe` 和 `/presentation` 地址，保存座位号、上报 Token 与 Probe 配置。

--- a/packages/server/handler/monitor.ts
+++ b/packages/server/handler/monitor.ts
@@ -1,3 +1,4 @@
+import net from 'net';
 import path from 'path';
 import { Context } from 'cordis';
 import fs from 'fs-extra';
@@ -114,6 +115,19 @@ class MonitorAdminHandler extends AuthHandler {
 
 const escape = (str = '') => str.trim().replace(/"/g, '\\"').replace(/\r/g, '').replace(/\n/g, '\\n');
 
+const UNROUTABLE_IPS = new Set(['127.0.0.1', '0.0.0.0', '::1', '::']);
+
+/**
+ * The address a machine reports for itself is the one that is actually reachable for SSH and
+ * Prometheus scrapes. The connection address is only a fallback: behind a reverse proxy it
+ * degrades to the loopback address of the proxy, and behind NAT it points at the gateway.
+ */
+function normalizeReportedIp(value: any) {
+    const ip = String(value ?? '').trim().replace(/^::ffff:/, '');
+    if (!net.isIP(ip) || UNROUTABLE_IPS.has(ip)) return '';
+    return ip;
+}
+
 async function saveMonitorInfo(ctx: Context, monitor: any) {
     const {
         mac, version, uptime, seats, ip,
@@ -228,7 +242,7 @@ class MachineProbeConnectionHandler extends ConnectionHandler<Context> {
             version: probe.version || 'machine-tools',
             uptime: probe.uptime || 0,
             seats: probe.hostname || this.mac,
-            ip: this.request.ip.replace('::ffff:', ''),
+            ip: normalizeReportedIp(probe.ip) || this.request.ip.replace('::ffff:', ''),
             os: probe.os,
             kernel: probe.kernel,
             cpu: probe.cpu,

--- a/scripts/machine_tools_probe.py
+++ b/scripts/machine_tools_probe.py
@@ -315,6 +315,7 @@ def machine_snapshot(config):
     return {
         "mac": identity["mac"],
         "hostname": configured_seat(config),
+        "ip": identity["ip"],
         "version": image_revision(),
         "uptime": uptime,
         "os": operating_system_name(),


### PR DESCRIPTION
## 问题

反向代理后面的选手机，`monitor.ip` 全部被记录成 `127.0.0.1`。

`saveProbe` 从 WebSocket 连接的来源地址取 IP：

https://github.com/hydro-dev/xcpc-tools/blob/23d1bb4/packages/server/handler/monitor.ts#L231

但服务端从未开启 Koa 的 `proxy` / `xff` 选项（`packages/server/service/server.ts:12`），所以前面挂 Nginx 时这个地址就是代理的回环地址；选手机在 NAT 后面时则是网关地址。这个地址随后被 WebSSH（`handler/ssh.ts:47`）和 Prometheus `/sd`（`handler/monitor.ts:335`）当作目标使用，两者都会指向错误的机器——`/sd` 的情况下等于让 Prometheus 抓取服务端自己。

## 改动

改为优先采用选手机自己上报的地址，这个地址才是 SSH 和抓取真正可达的那一个。

这个字段本来就在协议里：Machine Tools 客户端一直以 `MachineSnapshot.ip` 上报（`packages/machine-tools/frontend/src/utils/system.ts:302`），只是服务端把它丢掉了；Python probe 在 `network_identity()` 里算出了这个地址（用于取 MAC 和 Wi-Fi 信息），但没有放进上报内容。

- `scripts/machine_tools_probe.py`：`machine_snapshot()` 补上 `ip` 字段。
- `packages/server/handler/monitor.ts`：`normalizeReportedIp(probe.ip) || this.request.ip`。用 `net.isIP` 校验并拒绝回环与未指定地址，避免非法值进入 SSH host 或 Prometheus target 字符串；保留连接来源地址作为回退，旧 probe 行为不变。
- `README.md`：在 Monitor 一节说明取值优先级。

HTTP `/report`（v1）沿用原有行为：`scripts/monitor` 不上报 `ip`，没有可采用的值。

## 验证

用真实 Python probe 连真实服务端（nedb，端口 5299）跑通。从 localhost 连接即可复现代理场景，因为此时 `request.ip` 就是 `127.0.0.1`：

| | 记录的 `ip` | `/sd` target |
|---|---|---|
| 修复前 | `127.0.0.1` | `127.0.0.1:9100` — 抓取服务端自己 |
| 修复后 | `192.168.10.15` | `192.168.10.15:9100` |

另对取值逻辑跑了 12 个用例：NAT、字段缺失/为空、回环、非法值注入、非字符串、IPv6、IPv4-mapped、首尾空白，全部通过。`tsc --noEmit` 在 `monitor.ts` 上无报错。

仓库当前 `yarn lint` 在 `main` 上即失败（`ESLint couldn't find the config "airbnb-base"`），与本改动无关。
