### PR TITLE
fix(machine-tools): detect reporter units by unit file, not runtime state

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ hydro-machine-tools                 # 本机配置
 hydro-machine-tools --presentation  # 赛前展示
 ```
 
-座位号写入 `/var/lib/icpc/config.json`。如果镜像提供 `hydro-machine-tools.service`，配置程序把 Probe 地址和上报 Token 写入 `/etc/default/hydro-machine-tools`，启用 WebSocket Probe 并停用 `heartbeat.timer`；旧镜像则写入 `/etc/default/icpc-heartbeat`，继续使用 HTTP heartbeat。
+座位号写入 `/var/lib/icpc/config.json`。上报方式由镜像里实际存在的 unit 文件决定：提供 `hydro-machine-tools.service` 时把 Probe 地址和上报 Token 写入 `/etc/default/hydro-machine-tools`，启用 WebSocket Probe 并停用 `heartbeat.timer`（该 unit 不存在时跳过）；只提供 `heartbeat.timer` 的旧镜像写入 `/etc/default/icpc-heartbeat`，继续使用 HTTP heartbeat；两者都没有时直接提示镜像缺少上报服务。
 
 上报服务启动后，可在 `http://服务IP:5283/#/monitor` 查看选手机状态。
 

--- a/packages/machine-tools/frontend/src/components/SetupPanel.tsx
+++ b/packages/machine-tools/frontend/src/components/SetupPanel.tsx
@@ -17,8 +17,9 @@ import type {
 import { runPrivileged, writePrivilegedFile } from '../utils/privileged';
 import { testProbeReport } from '../utils/probe';
 import {
-    collectMachineSnapshot, deriveServerEndpoints, HEARTBEAT_CONFIG_PATH, heartbeatVersionUrl,
-    MACHINE_TOOLS_ENV_PATH, SEAT_CONFIG_PATH, shellQuote,
+    collectMachineSnapshot, deriveServerEndpoints, getProbeServiceState, getUnitActiveState,
+    HEARTBEAT_CONFIG_PATH, HEARTBEAT_SERVICE_UNIT, HEARTBEAT_TIMER_UNIT, heartbeatVersionUrl,
+    MACHINE_TOOLS_ENV_PATH, PROBE_SERVICE_UNIT, SEAT_CONFIG_PATH, shellQuote, unitFileExists,
 } from '../utils/system';
 import { MachineInfo } from './MachineInfo';
 import { VideoDebug, VideoQuickControls } from './VideoDebug';
@@ -91,11 +92,14 @@ function StatusTile({
     );
 }
 
+type ReporterMode = 'probe' | 'heartbeat';
+
 const probeServiceLabels: Record<ProbeServiceState, string> = {
     active: 'systemd 已启动',
     activating: 'systemd 启动中',
     inactive: 'systemd 未启动',
     failed: 'systemd 启动失败',
+    installed: '已安装，systemd 未运行',
     'not-found': '镜像缺少 systemd 服务',
     unknown: 'systemd 状态未知',
 };
@@ -112,6 +116,7 @@ export function SetupPanel({
     const [testingHeartbeat, setTestingHeartbeat] = useState(false);
     const [testingProbe, setTestingProbe] = useState(false);
     const [heartbeatTimerActive, setHeartbeatTimerActive] = useState(false);
+    const [heartbeatUnitInstalled, setHeartbeatUnitInstalled] = useState(false);
     const [heartbeatServiceResult, setHeartbeatServiceResult] = useState('');
     const [probeTest, setProbeTest] = useState<ProbeTestState>();
     const [operationError, setOperationError] = useState('');
@@ -121,7 +126,10 @@ export function SetupPanel({
     const [videoOpened, videoControls] = useDisclosure(false);
 
     const cleanSeat = seat.trim();
-    const useProbe = probeServiceState !== 'not-found' && probeServiceState !== 'unknown';
+    // `not-found` is the only state that positively rules the probe out; every other state means the
+    // unit file is installed, including `installed`, which is what a machine without a running
+    // systemd reports. This drives the display only — saving resolves the mode from disk instead.
+    const probeUnitInstalled = probeServiceState !== 'not-found' && probeServiceState !== 'unknown';
     const primaryNetwork = snapshot?.networks.find((network) => network.isDefault) || snapshot?.networks[0];
     const ip = snapshot?.ip || primaryNetwork?.ipv4[0] || '';
     const endpoints = useMemo(() => {
@@ -134,6 +142,8 @@ export function SetupPanel({
     const probeDetail = probeTest
         ? `最近测试：${new Date(probeTest.reportedAt).toLocaleTimeString()}`
         : '尚未测试';
+    let heartbeatTileValue = '镜像未安装';
+    if (heartbeatUnitInstalled) heartbeatTileValue = heartbeatTimerActive ? '定时器运行中' : '定时器未运行';
 
     const validateSeat = useCallback(() => {
         if (!cleanSeat || !/^[A-Za-z0-9][A-Za-z0-9-]{0,62}$/.test(cleanSeat)) {
@@ -145,11 +155,13 @@ export function SetupPanel({
     const currentReportToken = useCallback(() => reportToken.trim(), [reportToken]);
 
     const refreshHeartbeatState = useCallback(async () => {
-        const [timer, service] = await Promise.all([
-            os.execCommand('systemctl is-active heartbeat.timer').catch(() => undefined),
-            os.execCommand('systemctl show heartbeat.service --property=Result').catch(() => undefined),
+        const [installed, timerState, service] = await Promise.all([
+            unitFileExists(HEARTBEAT_TIMER_UNIT),
+            getUnitActiveState(HEARTBEAT_TIMER_UNIT),
+            os.execCommand(`systemctl show ${shellQuote(HEARTBEAT_SERVICE_UNIT)} --property=Result`).catch(() => undefined),
         ]);
-        setHeartbeatTimerActive(timer?.stdOut.trim() === 'active');
+        setHeartbeatUnitInstalled(installed);
+        setHeartbeatTimerActive(timerState === 'active');
         setHeartbeatServiceResult(service?.stdOut.trim().split('=')[1] || '');
     }, []);
 
@@ -235,11 +247,12 @@ export function SetupPanel({
     };
 
     const showHeartbeatService = async () => {
-        const result = await os.execCommand('systemctl status heartbeat.service --no-pager');
+        const unit = probeUnitInstalled ? PROBE_SERVICE_UNIT : HEARTBEAT_SERVICE_UNIT;
+        const result = await os.execCommand(`systemctl status ${shellQuote(unit)} --no-pager`);
         await refreshHeartbeatState();
         notifications.show({
             color: result.exitCode === 0 ? 'blue' : 'yellow',
-            title: 'heartbeat.service 状态',
+            title: `${unit} 状态`,
             message: result.stdOut || result.stdErr || 'No output',
             autoClose: 10_000,
         });
@@ -271,24 +284,51 @@ export function SetupPanel({
         }
     };
 
-    const restartProbe = async () => {
-        await runPrivileged('/usr/bin/systemctl', ['enable', 'hydro-machine-tools.service', '--now']);
-        await runPrivileged('/usr/bin/systemctl', ['restart', 'hydro-machine-tools.service']);
-        const state = await os.execCommand('systemctl is-active hydro-machine-tools.service');
-        if (state.stdOut.trim() !== 'active') {
-            throw new Error(state.stdErr || '镜像内置的 hydro-machine-tools.service 未启动');
-        }
-        onProbeServiceState('active');
+    /** Best effort: the reporter we are switching away from must never fail the whole save. */
+    const stopReporterUnit = async (unit: string) => {
+        if (!await unitFileExists(unit)) return;
+        await runPrivileged('/usr/bin/systemctl', ['disable', unit]).catch(() => undefined);
+        await runPrivileged('/usr/bin/systemctl', ['stop', unit]).catch(() => undefined);
     };
 
-    const startReporter = async () => {
-        if (useProbe) {
-            await restartProbe();
-            await runPrivileged('/usr/bin/systemctl', ['disable', 'heartbeat.timer', '--now']);
-        } else {
-            await runPrivileged('/usr/bin/systemctl', ['enable', 'heartbeat.timer', '--now']);
+    /** Resolve the reporter from the unit files that are actually present, never from stale state. */
+    const resolveReporterMode = async (): Promise<ReporterMode> => {
+        const [probeInstalled, heartbeatInstalled] = await Promise.all([
+            unitFileExists(PROBE_SERVICE_UNIT),
+            unitFileExists(HEARTBEAT_TIMER_UNIT),
+        ]);
+        setHeartbeatUnitInstalled(heartbeatInstalled);
+        if (probeInstalled) return 'probe';
+        if (heartbeatInstalled) return 'heartbeat';
+        throw new Error(`镜像既没有 ${PROBE_SERVICE_UNIT} 也没有 ${HEARTBEAT_TIMER_UNIT}，无法启动上报服务`);
+    };
+
+    const startProbe = async () => {
+        // `enable` still works without a running manager, `restart` is the part systemd skips when
+        // there is none. Keeping them apart means `enable --now` cannot fail the save just for that.
+        await runPrivileged('/usr/bin/systemctl', ['enable', PROBE_SERVICE_UNIT]);
+        await runPrivileged('/usr/bin/systemctl', ['restart', PROBE_SERVICE_UNIT]);
+        const state = await getProbeServiceState();
+        onProbeServiceState(state);
+        if (state === 'active') return '已启用 WebSocket Probe';
+        // Without a running manager nothing can be started, so enabling it is all that can be done.
+        if (state === 'installed') {
+            return `已启用 WebSocket Probe，${PROBE_SERVICE_UNIT} 已设为开机自启（当前环境没有运行中的 systemd）`;
         }
+        throw new Error(`${PROBE_SERVICE_UNIT} 未能启动（当前状态：${state}），请用「服务状态」查看日志`);
+    };
+
+    const startReporter = async (mode: ReporterMode) => {
+        if (mode === 'probe') {
+            const summary = await startProbe();
+            await stopReporterUnit(HEARTBEAT_TIMER_UNIT);
+            await refreshHeartbeatState();
+            return summary;
+        }
+        await runPrivileged('/usr/bin/systemctl', ['enable', HEARTBEAT_TIMER_UNIT]);
+        await runPrivileged('/usr/bin/systemctl', ['restart', HEARTBEAT_TIMER_UNIT]);
         await refreshHeartbeatState();
+        return '已启用 HTTP heartbeat';
     };
 
     const saveReporting = async (force: boolean) => {
@@ -297,11 +337,12 @@ export function SetupPanel({
         try {
             const resolved = endpoints;
             if (!resolved) throw new Error('请输入有效的服务器或 HEARTBEATURL');
+            const mode = await resolveReporterMode();
             if (!force) {
-                if (useProbe) await testProbe(false);
+                if (mode === 'probe') await testProbe(false);
                 else await testHeartbeat(false);
             }
-            if (useProbe) {
+            if (mode === 'probe') {
                 await writePrivilegedFile(
                     MACHINE_TOOLS_ENV_PATH,
                     `PROBEURL=${shellQuote(resolved.probeUrl)}\nREPORTTOKEN=${shellQuote(currentReportToken())}\n`,
@@ -314,13 +355,13 @@ export function SetupPanel({
             }
             onConfigChange({
                 ...configForEndpoints(),
-                probeEnabled: useProbe,
+                probeEnabled: mode === 'probe',
             });
-            await startReporter();
+            const summary = await startReporter(mode);
             notifications.show({
                 color: 'blue',
                 title: force ? '已强制保存上报配置' : '上报配置已测试并保存',
-                message: useProbe ? '已启用 WebSocket Probe' : '已启用 HTTP heartbeat',
+                message: summary,
             });
         } catch (error) {
             setOperationError((error as Error).message);
@@ -339,10 +380,10 @@ export function SetupPanel({
             const hostname = await os.execCommand('hostname').then((result) => result.stdOut.trim()).catch(() => '');
             if (!force && hostname !== nextSeat) throw new Error('主机名与座位号不匹配，请先保存座位号');
             if (!force && !ip) throw new Error('未获取到内网 IP，请检查网络连接');
-            if (!force && (!config.heartbeatUrl || (useProbe && !config.probeEnabled))) {
+            if (!force && (!config.heartbeatUrl || (probeUnitInstalled && !config.probeEnabled))) {
                 throw new Error('上报配置尚未保存，请先保存上报配置');
             }
-            await startReporter();
+            await startReporter(await resolveReporterMode());
             const markup = `<span font='${nextSeat.length > 4 ? 128 : 256}'>${nextSeat}\n</span><span font='128'>${ip}</span>`;
             os.execCommand(`zenity --info --text ${shellQuote(markup)} > /dev/null 2>&1 &`).catch(() => undefined);
             notifications.show({
@@ -416,12 +457,12 @@ export function SetupPanel({
                         <StatusTile
                             icon={IconActivityHeartbeat}
                             label="HTTP Heartbeat"
-                            value={heartbeatTimerActive ? '定时器运行中' : '定时器未运行'}
-                            detail="heartbeat.timer"
+                            value={heartbeatTileValue}
+                            detail={HEARTBEAT_TIMER_UNIT}
                         />
                         <StatusTile
                             icon={IconServer}
-                            label="heartbeat.service"
+                            label={HEARTBEAT_SERVICE_UNIT}
                             value={heartbeatServiceResult || '未知'}
                             detail="Result 每 30 秒刷新"
                         />
@@ -475,13 +516,14 @@ export function SetupPanel({
                         </Group>
 
                         <Divider
-                            label={useProbe ? 'WebSocket Probe（当前上报方式）' : 'WebSocket Probe（镜像未安装）'}
+                            label={probeUnitInstalled
+                                ? `WebSocket Probe（当前上报方式 · ${probeServiceLabels[probeServiceState]}）`
+                                : `WebSocket Probe（镜像未安装 ${PROBE_SERVICE_UNIT}）`}
                             labelPosition="center"
                         />
                         <Group grow>
                             <Button
                                 variant="light"
-                                disabled={!useProbe}
                                 loading={testingProbe}
                                 onClick={() => testProbe().catch(() => undefined)}
                             >

--- a/packages/machine-tools/frontend/src/types.ts
+++ b/packages/machine-tools/frontend/src/types.ts
@@ -32,7 +32,12 @@ export interface MachineSnapshot {
     networks: NetworkInterfaceInfo[];
 }
 
-export type ProbeServiceState = 'active' | 'activating' | 'inactive' | 'failed' | 'not-found' | 'unknown';
+/**
+ * `installed` means the unit file is present but systemd cannot report its runtime state, which is
+ * the case whenever there is no running manager to ask.
+ */
+export type ProbeServiceState =
+    | 'active' | 'activating' | 'inactive' | 'failed' | 'installed' | 'not-found' | 'unknown';
 
 export interface MachineToolsConfig {
     seat?: string;

--- a/packages/machine-tools/frontend/src/utils/system.ts
+++ b/packages/machine-tools/frontend/src/utils/system.ts
@@ -7,6 +7,9 @@ import type {
 export const SEAT_CONFIG_PATH = '/var/lib/icpc/config.json';
 export const HEARTBEAT_CONFIG_PATH = '/etc/default/icpc-heartbeat';
 export const MACHINE_TOOLS_ENV_PATH = '/etc/default/hydro-machine-tools';
+export const PROBE_SERVICE_UNIT = 'hydro-machine-tools.service';
+export const HEARTBEAT_TIMER_UNIT = 'heartbeat.timer';
+export const HEARTBEAT_SERVICE_UNIT = 'heartbeat.service';
 export const PRESENTATION_CACHE_PATH = `/tmp/xcpc-tools-presentation-${window.NL_PID || 'session'}.json`;
 const PRESENTATION_CACHE_TEMP_PATH = `${PRESENTATION_CACHE_PATH}.tmp`;
 let presentationCacheOperation = Promise.resolve<unknown>(undefined);
@@ -16,21 +19,6 @@ export interface MachineToolsEndpoints {
     heartbeatUrl: string;
     probeUrl: string;
     presentationUrl: string;
-}
-
-export async function getProbeServiceState(): Promise<ProbeServiceState> {
-    try {
-        const loadState = await os.execCommand(
-            'systemctl show hydro-machine-tools.service --property=LoadState --value',
-        );
-        if (loadState.stdOut.trim() !== 'loaded') return 'not-found';
-        const result = await os.execCommand('systemctl is-active hydro-machine-tools.service');
-        const state = result.stdOut.trim();
-        if (['active', 'activating', 'inactive', 'failed'].includes(state)) return state as ProbeServiceState;
-        return 'unknown';
-    } catch {
-        return 'unknown';
-    }
 }
 
 interface IpAddressEntry {
@@ -46,6 +34,47 @@ interface IpRouteEntry {
 
 export function shellQuote(value: string) {
     return `'${value.replace(/'/g, '\'"\'"\'')}'`;
+}
+
+const UNIT_STATE_ALIASES: Record<string, ProbeServiceState> = {
+    active: 'active',
+    reloading: 'active',
+    activating: 'activating',
+    deactivating: 'inactive',
+    inactive: 'inactive',
+    failed: 'failed',
+};
+
+/**
+ * `list-unit-files` is one of the few verbs that still answers without a running manager, so it is
+ * the only reliable way to tell a missing unit apart from an unreachable systemd. Online-only verbs
+ * such as `show` and `is-active` log "Running in chroot, ignoring command '<verb>'" to stderr and
+ * exit 0 with empty stdout when no manager is running, which reads exactly like "not found".
+ */
+export async function unitFileExists(unit: string) {
+    const result = await os.execCommand(
+        `systemctl list-unit-files ${shellQuote(unit)} --no-legend --no-pager`,
+    ).catch(() => undefined);
+    return result?.exitCode === 0 && Boolean(result.stdOut.trim());
+}
+
+/** Runtime state of a unit, or an empty string when systemd cannot answer (no running manager). */
+export async function getUnitActiveState(unit: string) {
+    const result = await os.execCommand(`systemctl is-active ${shellQuote(unit)}`).catch(() => undefined);
+    return result?.stdOut.trim() || '';
+}
+
+export async function getProbeServiceState(): Promise<ProbeServiceState> {
+    try {
+        if (!await unitFileExists(PROBE_SERVICE_UNIT)) return 'not-found';
+        const state = await getUnitActiveState(PROBE_SERVICE_UNIT);
+        // Empty output means there was no manager to ask, not that the unit is missing. Anything
+        // else came from a live systemd, so it must not be reported as "no running systemd".
+        if (!state) return 'installed';
+        return UNIT_STATE_ALIASES[state] || 'unknown';
+    } catch {
+        return 'unknown';
+    }
 }
 
 export function isPrivateIPv4(ip: string) {


### PR DESCRIPTION
## Problem

Saving the reporting settings in Machine Tools always enabled the legacy HTTP heartbeat instead of the WebSocket probe, and then failed outright on images that ship no `heartbeat.timer`:

```
Failed to enable unit: Unit file heartbeat.timer does not exist.
```

The reporter was inferred from `getProbeServiceState()`, which asked systemd about `hydro-machine-tools.service` via:

```ts
systemctl show hydro-machine-tools.service --property=LoadState --value
```

`show` is one of systemd's `VERB_ONLINE_ONLY` verbs. With no running manager — which is the case inside a chroot image during image build — systemd logs `Running in chroot, ignoring command 'show'` **to stderr, exits 0, and leaves stdout empty**. The code read `stdOut.trim()`, saw `''`, concluded `not-found`, and fell through to the legacy branch even though the probe unit was installed. `systemctl enable heartbeat.timer --now` then exited 1 because that unit genuinely does not exist on such images.

Verified on systemd 261:

| command | live system | no running manager |
| --- | --- | --- |
| `show --property=LoadState --value` | `loaded` | *(empty stdout, exit 0)* |
| `is-active` | `active` | *(empty stdout, exit 0)* |
| `list-unit-files <unit>` | exit 0 + output | **exit 0 + output** |
| `enable <unit>` | exit 0 | **exit 0** (pure file operation) |
| `restart <unit>` | exit 0 | exit 0 (ignored) |

## Fix

`systemctl list-unit-files` and `enable`/`disable` keep working without a manager, so the detection is rebuilt on those.

- **`utils/system.ts`** — new `unitFileExists()` (via `list-unit-files`) and `getUnitActiveState()`. `getProbeServiceState()` now establishes unit-file presence first and only then reads the runtime state. Empty `is-active` output means "no manager to ask", surfaced as a new `installed` state rather than `not-found`. Live states systemd may report but the union does not model (`reloading`, `deactivating`) are mapped explicitly instead of collapsing into `installed`, so a booted machine is never labelled as having no systemd.
- **`components/SetupPanel.tsx`** — saving resolves the reporter through `resolveReporterMode()`, reading the unit files on disk instead of possibly-stale React state, so the env file that gets written and the unit that gets started can no longer disagree. `enable` is split from `--now` (`restart` is skipped by systemd when there is no manager and exits 0), disabling the other reporter is skipped when its unit is absent, and an image with neither unit produces an explicit error instead of an attempt to enable something that does not exist.
- **`types.ts`** — `ProbeServiceState` gains `installed`.
- **`README.md`** — describes reporter selection as unit-file driven.

Mode selection stays fully automatic; no new UI control, and the app still installs no runtime components.

## Behaviour

| Image | Before | After |
| --- | --- | --- |
| probe unit only, no running manager | ❌ error on `heartbeat.timer` | ✅ probe |
| probe unit only, booted | ✅ probe | ✅ probe |
| `heartbeat.timer` only (legacy) | ✅ heartbeat | ✅ heartbeat |
| both units | ✅ probe | ✅ probe |
| neither unit | ❌ `Unit file heartbeat.timer does not exist` | ✅ explicit "no reporting service in image" error |

## Verification

- `tsc -b` clean.
- ESLint clean on all changed files (the sole remaining warning is on an untouched line; the pre-existing errors in `PresentationPage.tsx` are unrelated and unmodified).
- `vite build` succeeds.
- Mode resolution exercised against real `systemctl` in scratch roots for all four image layouts in the table above, plus the full `is-active` → state mapping.

## Note for reviewers

One deliberate behaviour change: when **neither** unit is installed, 强制保存 no longer writes the env file, because the mode is now resolved before the write. Previously the file was written and the save then failed at `enable`. Nothing consumes that file on an image without either unit, but it is a real difference — happy to reorder if the write-then-fail behaviour is preferred.
